### PR TITLE
[WIP] Pebble integration

### DIFF
--- a/harbour-berail.pro
+++ b/harbour-berail.pro
@@ -80,6 +80,7 @@ RESOURCES += \
     qml/resources/resources.qrc
 
 HEADERS += \
+    src/connectiontracker.h \
     src/logger.h \
     src/os.h \
     src/api.h \
@@ -105,6 +106,7 @@ HEADERS += \
     src/models/stopabstract.h
 
 SOURCES += src/harbour-berail.cpp \
+    src/connectiontracker.cpp \
     src/logger.cpp \
     src/os.cpp \
     src/api.cpp \

--- a/qml/components/TripDelegate.qml
+++ b/qml/components/TripDelegate.qml
@@ -34,6 +34,7 @@ ListItem {
         anchors.fill: parent
         z: 1
         onClicked: _showVias == true? _showVias = false: _showVias = true
+        onPressAndHold: connectionTracker.toggleTracked(model.id)
         enabled: vias.count() > 0
     }
 

--- a/qml/harbour-berail.qml
+++ b/qml/harbour-berail.qml
@@ -16,11 +16,13 @@
 */
 
 import QtQuick 2.2
+import QtQml.Models 2.2
 import Sailfish.Silica 1.0
 import Nemo.Configuration 1.0
 import Nemo.DBus 2.0
 import Harbour.BeRail.API 1.0
 import Harbour.BeRail.SFOS 1.0
+import Harbour.BeRail.ConnectionTracker 1.0
 import "pages"
 import "components"
 
@@ -71,6 +73,21 @@ ApplicationWindow
     API {
         id: api
         onErrorOccurred: sfos.createToaster(errorText, "icon-s-high-importance", "x-harbour-berail")
+    }
+
+    ConnectionTracker {
+        id: connectionTracker
+        api: api
+    }
+
+    Connections {
+        target: connectionTracker
+        onConnectionTracked: {
+            sfos.createToaster("Added to tracked routes", "icon-s-new", "x-harbour-berail")
+        }
+        onConnectionUntracked: {
+            sfos.createToaster("Deleted from tracked routes", "icon-m-input-remove", "x-harbour-berail")
+        }
     }
 
     DBusInterface {

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -650,7 +650,7 @@ Liveboard *API::parseLiveboard(QJsonObject json)
 ConnectionListModel* API::parseConnections(QJsonObject json)
 {
     qDebug() << "Parsing connections";
-    QList<Connection*> connectionList;
+    QList<QSharedPointer<Connection>> connectionList;
     QJsonArray connectionArray = json["connection"].toArray();
     QDateTime timestampConnections;
     timestampConnections.setTime_t(json["timestamp"].toString().toInt());
@@ -827,7 +827,7 @@ ConnectionListModel* API::parseConnections(QJsonObject json)
 
         IRail::Occupancy connectionOccupancy = this->parseOccupancy(connectionOccupancyObj["name"].toString());
         // TO DO: enable disturbances and remarks for the whole connection
-        Connection* connection = new Connection(connectionId, fromStop, toStop, fromVehicleId, toVehicleId, disturbancesConnection, remarksConnection, connectionOccupancy, connectionDuration, new ViaListModel(viaList), timestampConnections);
+        QSharedPointer<Connection> connection(new Connection(connectionId, fromStop, toStop, fromVehicleId, toVehicleId, disturbancesConnection, remarksConnection, connectionOccupancy, connectionDuration, new ViaListModel(viaList), timestampConnections));
         connectionList.append(connection);
         qDebug() << "CONNECTION:";
         qDebug() << "\tFrom:" << connection->from()->station()->name();

--- a/src/connectiontracker.cpp
+++ b/src/connectiontracker.cpp
@@ -1,0 +1,34 @@
+#include <QDebug>
+
+#include "connectiontracker.h"
+
+#include "models/vialistmodel.h"
+#include "api.h"
+#include "os.h"
+
+ConnectionTracker::ConnectionTracker(QObject *parent)
+    : QObject(parent), m_connections()
+{
+
+}
+
+
+void ConnectionTracker::toggleTracked(int i) {
+    auto connection = m_api->connections()->connectionList()[i];
+
+    auto uuid = connection->uuid();
+    qDebug() << "toggle tracking of" << connection->from()->station()->name() << " to " << connection->to()->station()->name()
+             << "with uuid" << uuid;
+
+    if(m_connections.contains(uuid)) {
+        m_connections.remove(uuid);
+        emit connectionUntracked(uuid);
+    } else {
+        m_connections.insert(uuid, connection);
+
+        auto raw = connection.data();
+        QQmlEngine::setObjectOwnership(raw, QQmlEngine::ObjectOwnership::CppOwnership);
+
+        emit connectionTracked(uuid, raw);
+    }
+}

--- a/src/connectiontracker.h
+++ b/src/connectiontracker.h
@@ -1,0 +1,35 @@
+#ifndef CONNECTIONTRACKER_H
+#define CONNECTIONTRACKER_H
+
+#include <QObject>
+#include <QUuid>
+#include <QMap>
+
+#include "models/connection.h"
+#include "models/vialistmodel.h"
+
+#include "os.h"
+#include "api.h"
+
+class ConnectionTracker: public QObject {
+    Q_OBJECT
+    Q_PROPERTY(API *api MEMBER m_api)
+public:
+    ConnectionTracker(QObject *parent = nullptr);
+    Q_INVOKABLE void toggleTracked(int i);
+
+    void setApi(API *api) { this->m_api = api; }
+    API *api() { return this->m_api; }
+
+signals:
+    // Raw pointer is needed for exposure in Qml
+    void connectionTracked(QUuid uuid, Connection *connection);
+    void connectionUntracked(QUuid uuid);
+
+private:
+    QMap<QUuid, QSharedPointer<Connection>> m_connections;
+    API *m_api;
+    OS sfos;
+};
+
+#endif // CONNECTIONTRACKER_H

--- a/src/harbour-berail.cpp
+++ b/src/harbour-berail.cpp
@@ -29,6 +29,7 @@
 #include "logger.h"
 #include "os.h"
 #include "api.h"
+#include "connectiontracker.h"
 #include "models/station.h"
 
 // Add toString() method to all custom method
@@ -71,6 +72,7 @@ int main(int argc, char *argv[])
     qmlRegisterUncreatableType<IRail>("Harbour.BeRail.Models", 1, 0, "IRail", "read only");
     qmlRegisterType<API>("Harbour.BeRail.API", 1, 0, "API");
     qmlRegisterType<OS>("Harbour.BeRail.SFOS", 1, 0, "SFOS");
+    qmlRegisterType<ConnectionTracker>("Harbour.BeRail.ConnectionTracker", 1, 0, "ConnectionTracker");
 
     // Start the application.
     view->setSource(SailfishApp::pathTo("qml/harbour-berail.qml"));

--- a/src/models/connection.h
+++ b/src/models/connection.h
@@ -20,6 +20,7 @@
 #include <QtCore/QObject>
 #include <QtCore/QList>
 #include <QtCore/QString>
+#include <QUuid>
 #include "stop.h"
 #include "disturbances.h"
 #include "remarks.h"
@@ -37,6 +38,7 @@ class Connection: public QObject
     Q_PROPERTY(int duration READ duration WRITE setDuration NOTIFY durationChanged)
     Q_PROPERTY(ViaListModel* vias READ vias WRITE setVias NOTIFY viasChanged)
     Q_PROPERTY(QDateTime timestamp READ timestamp WRITE setTimestamp NOTIFY timestampChanged)
+    Q_PROPERTY(QUuid uuid READ uuid)
 
 public:
     explicit Connection(int id,
@@ -75,6 +77,7 @@ public:
     void setVias(ViaListModel *vias);
     QDateTime timestamp() const;
     void setTimestamp(const QDateTime &value);
+    QUuid uuid() const;
 
 signals:
     void idChanged();
@@ -89,6 +92,8 @@ signals:
     void timestampChanged();
 
 private:
+    void computeUuid();
+
     int m_id;
     Stop* m_from;
     Stop* m_to;
@@ -100,6 +105,7 @@ private:
     int m_duration;
     ViaListModel* m_vias;
     QDateTime m_timestamp;
+    QUuid m_uuid;
 };
 
 #endif // CONNECTION_H

--- a/src/models/connectionlistmodel.cpp
+++ b/src/models/connectionlistmodel.cpp
@@ -15,19 +15,15 @@
 *   along with BeRail.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "connectionlistmodel.h"
+#include <QSharedPointer>
 
-ConnectionListModel::ConnectionListModel(QList<Connection *> connectionList)
+ConnectionListModel::ConnectionListModel(QList<QSharedPointer<Connection>> connectionList)
 {
     this->setConnectionList(connectionList);
 }
 
 ConnectionListModel::~ConnectionListModel()
 {
-    if(!this->connectionList().isEmpty()) {
-        foreach(Connection* item, this->connectionList()) {
-            item->deleteLater();
-        }
-    }
 }
 
 int ConnectionListModel::rowCount(const QModelIndex &) const
@@ -136,12 +132,12 @@ QVariant ConnectionListModel::data(const QModelIndex &index, int role) const
     }
 }
 
-QList<Connection *> ConnectionListModel::connectionList() const
+QList<QSharedPointer<Connection>> ConnectionListModel::connectionList() const
 {
     return m_connectionList;
 }
 
-void ConnectionListModel::setConnectionList(const QList<Connection *> &connectionList)
+void ConnectionListModel::setConnectionList(const QList<QSharedPointer<Connection>> &connectionList)
 {
     m_connectionList = connectionList;
 }

--- a/src/models/connectionlistmodel.h
+++ b/src/models/connectionlistmodel.h
@@ -41,14 +41,14 @@ public:
         TimestampRole = Qt::UserRole + 11
     };
 
-    explicit ConnectionListModel(QList<Connection *> connectionList);
+    explicit ConnectionListModel(QList<QSharedPointer<Connection>> connectionList);
     explicit ConnectionListModel();
     ~ConnectionListModel();
 
     virtual int rowCount(const QModelIndex&) const;
     virtual QVariant data(const QModelIndex &index, int role) const;
-    QList<Connection *> connectionList() const;
-    void setConnectionList(const QList<Connection *> &connectionList);
+    QList<QSharedPointer<Connection>> connectionList() const;
+    void setConnectionList(const QList<QSharedPointer<Connection>> &connectionList);
 
     Station *from() const;
     void setFrom(Station *from);
@@ -65,7 +65,7 @@ protected:
     QHash<int, QByteArray> roleNames() const;
 
 private:
-    QList<Connection *> m_connectionList;
+    QList<QSharedPointer<Connection>> m_connectionList;
     Station* m_from;
     Station* m_to;
     QDateTime m_time;


### PR DESCRIPTION
1. **Explanation**: 
    1. Bare-minimum UX for #14: keep track of "favorite connections" to receive notifications through a long press on a connection. Connections are stored in a QMap at C++-side, and Connections have a Uuid based on a hash of departure, arrivals and vias.
    2. Connections are stored behind `QSharedPointer` because of the shared ownership (ConnectionListModel and ConnectionTracker share the data). 

2. **Fixed issues**: 
    - part of #14: `ConnectionTracker` keeps track of "followed connections", for notification systems (such as Pebble, or real SailfishOS notifications).
    - WIP: #44

3. **Testing environment**: 
    - Sailfish OS version: 3.2
    - Sailfish OS hardware: Xperia 10 (21:1 screen)
    - Pebble Steel, Pebble Time.

I have two working Pebble watches to test since date of posting. Seems like the Toaster I generate also generates a notification on the watch; maybe @abranson might take a look at how [a toaster à la here](https://github.com/iRail/harbour-berail/blob/develop/src/os.cpp#L144) generates an (in my opinion) unneeded notification.
